### PR TITLE
meteor-mysql-1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # numtel:mysql [![Build Status](https://travis-ci.org/numtel/meteor-mysql.svg?branch=master)](https://travis-ci.org/numtel/meteor-mysql)
-Reactive MySQL for Meteor
+Reactive MySQL for Meteor <b>1.7</b>
 
 Provides Meteor integration of the [`mysql-live-select` NPM module](https://github.com/numtel/mysql-live-select), bringing reactive `SELECT` statement result sets from MySQL >= 5.1.15.
 

--- a/lib/LiveMysql.js
+++ b/lib/LiveMysql.js
@@ -5,6 +5,9 @@ var Future = Npm.require('fibers/future');
 
 LiveMysql = Npm.require('mysql-live-select');
 
+import _ from "lodash";
+
+
 // Convert the LiveMysqlSelect object into a cursor
 LiveMysql.LiveMysqlSelect.prototype._publishCursor = function(sub) {
   var self = this;
@@ -71,3 +74,5 @@ LiveMysql.LiveMysqlSelect.prototype.fetch = function() {
 
   return dataWithIds;
 }
+
+module.exports = LiveMysql;

--- a/lib/MysqlSubscription.js
+++ b/lib/MysqlSubscription.js
@@ -54,8 +54,6 @@ MysqlSubscription = function(connection, name /* arguments */){
     instance: self,
     resetOnDiff: false
   });
-  console.log("buffer");
-  console.log(buffer);
 
   // If first store for this subscription name, register it!
   if(_.filter(buffer, function(sub){

--- a/lib/MysqlSubscription.js
+++ b/lib/MysqlSubscription.js
@@ -1,9 +1,13 @@
 // numtel:mysql
 // MIT License, ben@latenightsketches.com
 // lib/MysqlSubscription.js
+import { Tracker } from 'meteor/tracker';
+import _ from "lodash";
 
 var selfConnection;
 var buffer = [];
+
+
 
 MysqlSubscription = function(connection, name /* arguments */){
   var self = this;
@@ -20,6 +24,7 @@ MysqlSubscription = function(connection, name /* arguments */){
     subscribeArgs = Array.prototype.slice.call(arguments, 0);
     name = connection;
     if(Meteor.isClient){
+
       connection = Meteor.connection;
     }else if(Meteor.isServer){
       if(!selfConnection){
@@ -32,7 +37,9 @@ MysqlSubscription = function(connection, name /* arguments */){
     subscribeArgs = Array.prototype.slice.call(arguments, 1);
   }
 
-  Tracker.Dependency.call(self);
+  var _tracker = Tracker.Dependency.bind(self);
+  Object.assign(self, new _tracker());
+
   // Y U No give me subscriptionId, Meteor?!
   var subsBefore = _.keys(connection._subscriptions);
   _.extend(self, connection.subscribe.apply(connection, subscribeArgs));
@@ -47,6 +54,8 @@ MysqlSubscription = function(connection, name /* arguments */){
     instance: self,
     resetOnDiff: false
   });
+  console.log("buffer");
+  console.log(buffer);
 
   // If first store for this subscription name, register it!
   if(_.filter(buffer, function(sub){
@@ -54,6 +63,7 @@ MysqlSubscription = function(connection, name /* arguments */){
   }).length === 1){
     connection.registerStore(name, {
       update: function(msg){
+
         var subBuffers = _.filter(buffer, function(sub){
           return sub.subscriptionId === msg.id;
         });
@@ -71,6 +81,7 @@ MysqlSubscription = function(connection, name /* arguments */){
             msg.fields && msg.fields.reset === true){
           // This message indicates a reset of a result set
           if(subBuffer.resetOnDiff === false){
+            
             sub.dispatchEvent('reset', msg);
             sub.splice(0, sub.length);
           }
@@ -94,8 +105,9 @@ MysqlSubscription = function(connection, name /* arguments */){
 
           // Emit event for application
           sub.dispatchEvent('update', msg.fields.diff, sub);
-        }
-        sub.changed();
+
+        } 
+        sub.changed(msg, newData);
       }
     });
   }
@@ -103,8 +115,11 @@ MysqlSubscription = function(connection, name /* arguments */){
 };
 
 // Inherit from Array and Tracker.Dependency
-MysqlSubscription.prototype = new Array;
-_.extend(MysqlSubscription.prototype, Tracker.Dependency.prototype);
+MysqlSubscription.prototype = [];
+//_.extend(MysqlSubscription.prototype, Tracker.Dependency.prototype);
+MysqlSubscription.prototype.depend = Tracker.Dependency.prototype.depend; //Seems like the only dependency.
+
+
 
 /*
  * Change the arguments for the subscription. Publication name and connection
@@ -236,3 +251,4 @@ function applyDiff(data, diff) {
   });
 }
 
+module.exports = MysqlSubscription;


### PR DESCRIPTION
Changes required to have it running with Meteor 1.7. **.change**, and **dispatchEvent** functionality **confirmed**.
**.reactive** / .**depend** are not confirmed to work yet.
**lodash must be imported into the project that utilizes MysqlSubscription / MysqlLive.**